### PR TITLE
Suspend element only in queue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "akka-stream-map-async-partition"
 
 ThisBuild / organization := "com.github.jaceksokol"
-ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / scalaVersion := "2.13.7"
 ThisBuild / versionScheme := Some("semver-spec")
 
 publishMavenStyle := true
@@ -27,7 +27,7 @@ scalacOptions ++= Seq(
   "-language:postfixOps"
 )
 
-val AkkaVersion = "2.6.16"
+val AkkaVersion = "2.6.17"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-stream-typed" % AkkaVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.2
+sbt.version = 1.5.5

--- a/src/main/scala/com/github/jaceksokol/akka/stream/MapAsyncPartition.scala
+++ b/src/main/scala/com/github/jaceksokol/akka/stream/MapAsyncPartition.scala
@@ -76,9 +76,9 @@ class MapAsyncPartition[In, Out, Partition](
         try {
           val element = Contextual(contextPropagation.currentContext(), grab(in))
           val partition = extractPartition(element.element)
-          element.suspend()
 
           if (inProgress.contains(partition) || inProgress.size >= parallelism) {
+            element.suspend()
             waiting.enqueue(partition -> element)
           } else {
             processElement(partition, element)
@@ -125,7 +125,6 @@ class MapAsyncPartition[In, Out, Partition](
               holder.elem match {
                 case Success(elem) =>
                   if (elem != null) {
-                    ctx.resume()
                     push(out, elem)
                     pullIfNeeded()
                   } else {
@@ -161,6 +160,7 @@ class MapAsyncPartition[In, Out, Partition](
             if (inProgress.size >= parallelism || inProgress.contains(partition)) {
               waiting.enqueue(partition -> element)
             } else {
+              element.resume()
               processElement(partition, element)
             }
           }


### PR DESCRIPTION
Main change:
Elements should not be suspended when they are being processed. If element being processed is suspended, calculated time of execution is does not contain time of async processing. Also there is danger that element won't be resumed if processing fails.

Additional change:
- dependencies update